### PR TITLE
remove italic tags from page title

### DIFF
--- a/agile-is-something-you-are-not-something-you-do.md
+++ b/agile-is-something-you-are-not-something-you-do.md
@@ -1,5 +1,5 @@
 ---
-title:  Agile is something you <i>are</i>, not something you do
+title:  Agile is something you are, not something you do
 ---
 If you take nothing else from all these words, take this. Agile is not a checklist, or a methodology, or a series of rituals. Agile is a way of thinking and a way of attacking problems. Embrace mistakes, learn, and keep trying. Mess up and learn again and again and again. Cut your losses. Fail forward fast. It’s okay. You won’t get fired. You’re learning. 
 


### PR DESCRIPTION
Removing italic tags from page title as they will not render correctly when the title is displayed in the browser (versus on the page, where they do render correctly). 

If there's another way to meet this need, let's hear it!

![screen shot 2018-05-03 at 5 24 46 pm](https://user-images.githubusercontent.com/1452369/39605643-0ae2fcfe-4ef7-11e8-8bd6-925105a6d68c.png)