### PR TITLE
Add guild meeting link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Agile guild 
 The Technology Transformation Service (TTS) agile guild is a community that fosters agile methodologies within government. For more on the guild, please see our [documentation](https://github.com/18F/agile/blob/18f-pages/guild/guild-readme.md).
 
+The guild meets every other Fridays from 2:00-2:30 ET.  For a link to the meeting, please consult the [TTS Guilds Meetings and Office Hours calendar](https://calendar.google.com/calendar/embed?src=gsa.gov_o1aqcv28k1f0nmca5bkch8los4%40group.calendar.google.com&ctz=America%2FChicago)
+
 # Agile guide
 The guild publishes an [agile guide](https://agile.18f.gov) that is based on  experience on 18F project teams and invdividuals inside and outside of government with experience in agile disciplines.  
 


### PR DESCRIPTION
For folks that are within TTS, add a link that will enable them to see the guild meeting calendar notice.