### PR TITLE
Fix current page navigation link styling

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -15,17 +15,17 @@ sidenav:
   - text: Introduction
     href: /
   - text: Modern software product development
-    href: /modern-software-product-development
+    href: /modern-software-product-development/
   - text: Agile is a thing already
-    href: /agile-is-a-thing-already
+    href: /agile-is-a-thing-already/
   - text: Agile is something you are, not something you do
-    href: /agile-is-something-you-are
+    href: /agile-is-something-you-are/
   - text: 18f Agile based project approach
-    href: /18f-agile-approach
+    href: /18f-agile-approach/
   - text: Agile fundamentals
-    href: /agile-fundamentals
+    href: /agile-fundamentals/
   - text: Agile lexicon
-    href: /agile-lexicon
+    href: /agile-lexicon/
 
 secondary:
   - text: 18F guides


### PR DESCRIPTION
This pull request seeks to address two issues:

1. Apply the [current page styling](https://designsystem.digital.gov/components/sidenav/) for the currently viewed page.
2. Avoid an unnecessary 301 redirect when navigating using sidebar links.

The canonical links for pages within the agile handbook include a trailing slash. Omitting a trailing slash will still function, but it requires a redirect, and the "current" link styling is not applied in the sidebar.

By updating the navigation data to include the trailing slash, the canonical link is considered accurately for applying current page styling, and for avoiding the redirect.

Before|After
---|---
![Before](https://user-images.githubusercontent.com/1779930/85303427-74fc7a00-b478-11ea-9375-17cd4e1a4a55.png)|![After](https://user-images.githubusercontent.com/1779930/85303446-7fb70f00-b478-11ea-8590-87990107f147.png)
