### PR TITLE
add subagency for DAP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
 
 gem 'uswds-jekyll', :git => 'https://github.com/18F/uswds-jekyll.git'
-gem 'jekyll_pages_api_search'
 gem 'jekyll-sitemap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/18F/uswds-jekyll.git
-  revision: 472991d0f798968dfc0fb4f7c096a0061f89f8cd
+  revision: 56ab3dc83d6c02ab731fdd63c1e3771ca77ffc2c
   specs:
-    uswds-jekyll (4.2.0)
-      jekyll (>= 3.4, < 5)
+    uswds-jekyll (5.0.1)
+      jekyll (>= 4.0, < 5)
 
 GEM
   remote: https://rubygems.org/
@@ -11,69 +11,67 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
-    concurrent-ruby (1.1.6)
-    em-websocket (0.5.1)
+    concurrent-ruby (1.1.7)
+    em-websocket (0.5.2)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
-    ffi (1.12.2)
+    ffi (1.13.1)
     forwardable-extended (2.6.0)
-    htmlentities (4.3.4)
     http_parser.rb (0.6.0)
-    i18n (0.9.5)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.7)
+    jekyll (4.1.1)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
-      i18n (~> 0.7)
-      jekyll-sass-converter (~> 1.0)
+      i18n (~> 1.0)
+      jekyll-sass-converter (~> 2.0)
       jekyll-watch (~> 2.0)
-      kramdown (~> 1.14)
+      kramdown (~> 2.1)
+      kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
-      mercenary (~> 0.3.3)
+      mercenary (~> 0.4.0)
       pathutil (~> 0.9)
-      rouge (>= 1.7, < 4)
+      rouge (~> 3.0)
       safe_yaml (~> 1.0)
-    jekyll-sass-converter (1.5.2)
-      sass (~> 3.4)
+      terminal-table (~> 1.8)
+    jekyll-sass-converter (2.1.0)
+      sassc (> 2.0.1, < 3.0)
     jekyll-sitemap (1.4.0)
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    jekyll_pages_api (0.1.6)
-      htmlentities (~> 4.3)
-      jekyll (>= 2.0, < 4.0)
-    jekyll_pages_api_search (0.5.0)
-      jekyll_pages_api (~> 0.1.4)
-      sass (~> 3.4)
-    kramdown (1.17.0)
+    kramdown (2.3.0)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     liquid (4.0.3)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    mercenary (0.3.6)
+    mercenary (0.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (4.0.5)
+    public_suffix (4.0.6)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rouge (3.18.0)
+    rexml (3.2.4)
+    rouge (3.23.0)
     safe_yaml (1.0.5)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
+    unicode-display_width (1.7.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   jekyll-sitemap
-  jekyll_pages_api_search
   uswds-jekyll!
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/_config.yml
+++ b/_config.yml
@@ -31,3 +31,4 @@ repos:
   url: https://github.com/18F/agile
 
 dap_agency: GSA
+dap_subagency: TTS


### PR DESCRIPTION
this is dependent on https://github.com/18F/uswds-jekyll/issues/204, and upgrading this project's Gemfile to include the updated `uswds-jekyll` .gem after it supports the `subagency` parameter.